### PR TITLE
Fix bug in DeployRaffle script causing insufficient balance when testing with VRFCoordinatorV2_5Mock

### DIFF
--- a/script/DeployRaffle.s.sol
+++ b/script/DeployRaffle.s.sol
@@ -12,16 +12,17 @@ contract DeployRaffle is Script {
         AddConsumer addConsumer = new AddConsumer();
         HelperConfig.NetworkConfig memory config = helperConfig.getConfig();
 
-        if (config.subscriptionId == 0) {
-            CreateSubscription createSubscription = new CreateSubscription();
-            (config.subscriptionId, config.vrfCoordinatorV2_5) =
-                createSubscription.createSubscription(config.vrfCoordinatorV2_5, config.account);
+        CreateSubscription createSubscription = new CreateSubscription();
+        (config.subscriptionId, config.vrfCoordinatorV2_5) = createSubscription
+            .createSubscription(config.vrfCoordinatorV2_5, config.account);
 
-            FundSubscription fundSubscription = new FundSubscription();
-            fundSubscription.fundSubscription(
-                config.vrfCoordinatorV2_5, config.subscriptionId, config.link, config.account
-            );
-        }
+        FundSubscription fundSubscription = new FundSubscription();
+        fundSubscription.fundSubscription(
+            config.vrfCoordinatorV2_5,
+            config.subscriptionId,
+            config.link,
+            config.account
+        );
 
         vm.startBroadcast(config.account);
         Raffle raffle = new Raffle(
@@ -35,7 +36,12 @@ contract DeployRaffle is Script {
         vm.stopBroadcast();
 
         // We already have a broadcast in here
-        addConsumer.addConsumer(address(raffle), config.vrfCoordinatorV2_5, config.subscriptionId, config.account);
+        addConsumer.addConsumer(
+            address(raffle),
+            config.vrfCoordinatorV2_5,
+            config.subscriptionId,
+            config.account
+        );
         return (raffle, helperConfig);
     }
 }


### PR DESCRIPTION
Removed the IF statement inside of the DeployRaffle.s.sol, which calls the create and fund subscription only if the subId == 0. The problem was that the subId is never 0, because the subId is created inside the HelperConfig.s.sol, which in the DeployRaffle contract is called before this IF statement. This introduced a bug which when testing the testFulFillRandomWordsPicksAWinnerResetsAndSendsMoney() from the RaffleTest.t.sol always fails with InsufficientBalance() error. This is because the fundSubscription() is never called, and the subscription never has link to execute fulfillRandomWords(). I tested this for a few days and logged the prevBal (which was always 0) and payment from the VRFCoordinatorV2_5Mock.sol, which confirmed this and led me to solving this bug in the end.